### PR TITLE
ci: Fix PR workflow [skip ci]

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -72,6 +72,6 @@ jobs:
           MYSQL_FAZCORD_DATABASE: faz-cord
           MYSQL_FAZWYNN_DATABASE: faz-wynn
         run: |
-          cp .env.example .env
-          uv run scripts/initdb.sh
+          cp .env-example .env
+          uv run scripts/initdb.py
           uv run pytest


### PR DESCRIPTION
Fix typo on `.env.example`. Should be `.env-example`.

Fix typ on `scripts/initdb.sh`. Should be `scripts/initdb.py`.